### PR TITLE
Audit package for vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     }
   },
   "dependencies": {
-    "@semantic-release/error": "^1.0.0"
+    "@semantic-release/error": "^1.0.0",
+    "nsp": "1.1.0"
   },
   "devDependencies": {
     "babel": "^5.5.8",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,16 @@
 const SRError = require('@semantic-release/error')
+var auditPackage = require('nsp/lib/auditPackage.js')
 
-module.exports = function (pluginConfig, config, cb) {
-  cb(null)
+module.exports = function (pluginConfig, packagePath, cb) {
+  if (!packagePath) {
+    packagePath = process.cwd() + '/package.json'
+  }
+
+  auditPackage(packagePath, (err, results) => {
+    if (err) return cb(new SRError('nsp returned unexpected error code', 'ENSPFAIL'))
+
+    if (results.length > 0) return cb(new SRError('Vulnerable Dependencies', 'EVULNERABLEDEPS'))
+
+    return cb(null)
+  })
 }

--- a/test/data/dep-package.json
+++ b/test/data/dep-package.json
@@ -1,0 +1,11 @@
+{
+  "name": "git-deps",
+  "version": "0.0.1",
+  "dependencies": {
+    "file-dep": "file:../node",
+    "some-dep": "https://github.com/joyent/node.git",
+    "other-dep": "git+ssh://git@github.com:nodesecurity/nsp.git",
+    "short-url-dep": "nodesecurity/nsp.git"
+  }
+}
+

--- a/test/data/vulnerable-package.json
+++ b/test/data/vulnerable-package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test",
+  "version": "0.0.1",
+  "author": "Node Security Project",
+  "dependencies": {
+    "node-print": "0.0.4",
+    "request": "^2.40.0",
+    "qs": "^0.5"
+  }
+}

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -3,10 +3,40 @@ const { test } = require('tap')
 const SRError = require('@semantic-release/error')
 
 const condition = proxyquire('../../', {
-  // ...
+  'auditPackage': (cb) => cb(null)
 })
 
-test('run-script', (t) => {
-  t.ok(condition)
-  t.end()
+test('find vulnerable packages', (tt) => {
+  tt.plan(2)
+
+  condition({}, 'test/data/vulnerable-package.json', (err, results) => {
+    tt.ok(err instanceof SRError)
+    tt.is(err.code, 'EVULNERABLEDEPS')
+  })
 })
+
+test('does not raise error on safe packages', (tt) => {
+  tt.plan(1)
+
+  condition({}, 'test/data/dep-package.json', (err) => {
+    tt.is(err, null)
+  })
+})
+
+test('requires proper path to package', (tt) => {
+  tt.plan(2)
+
+  condition({}, 'weird', (err) => {
+    tt.ok(err instanceof SRError)
+    tt.is(err.code, 'ENSPFAIL')
+  })
+})
+
+test('if no path given, path defaults to cwd + package.json', (tt) => {
+  tt.plan(1)
+
+  condition({}, '', (err) => {
+    tt.is(err, null)
+  })
+})
+


### PR DESCRIPTION
This PR contains a new feature: Auditing a package for vulnerabilities in it's dependencies.
- Using `nsp` we can audit a package's dependencies for known vulnerabilities and threats listed by the [Node Security Project](https://nodesecurity.io/).

The plugin will audit the **cwd**'s `package.json` file and if `nsp` finds any vulnerabilities, it will return a `SRError` otherwise it will return `null`.

Tests/test data are included

 resolves semantic-release/semantic-release#67
